### PR TITLE
fix: segmentation fault due to the `import` usage

### DIFF
--- a/lib/crypto/node.ts
+++ b/lib/crypto/node.ts
@@ -39,7 +39,7 @@ export { b as btoa };
 
 const crypto = (async () => {
   try {
-    return await import('crypto');
+    return await require('crypto');
   } catch (err) {
     // this environment has no crypto module!
     return undefined;


### PR DESCRIPTION
removed the dynamic imports of `crypto` module which causes segmentation fault in both ESM and CJS environments: https://github.com/okta/okta-auth-js/issues/1176